### PR TITLE
Refactor so that activities actually work by location (via zip too)

### DIFF
--- a/app/controllers/api/activities_controller.rb
+++ b/app/controllers/api/activities_controller.rb
@@ -13,9 +13,11 @@ class Api::ActivitiesController < ApplicationController
   end
 
   def index
-    calculate = ActivityPercentageCalculator.new(
-      Activity.where(date: Date.parse(params[:date]).in_time_zone.all_day)
-    )
+    activities = LocationProximityQuery.new(
+      Activity.where(date: Date.parse(params[:date]).in_time_zone.all_day),
+      zip_code: params[:zip_code]
+    ).nearby
+    calculate = ActivityPercentageCalculator.new(activities)
     render json: calculate.to_json
   end
 

--- a/app/controllers/api/air_quality_observations_controller.rb
+++ b/app/controllers/api/air_quality_observations_controller.rb
@@ -1,7 +1,7 @@
 class Api::AirQualityObservationsController < ApplicationController
   def index
-    query = AqoLocationProximityQuery.new(AQO.past_seven_days, params)
-    if query.focal_point
+    query = LocationProximityQuery.new(AQO.past_seven_days, params)
+    if query.nearby
       render json: query.nearby
     else
       render json: []

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,4 +1,6 @@
 class Activity < ActiveRecord::Base
+  acts_as_mappable
+
   validates :location,
             inclusion: {
               in: %w(inside outside),

--- a/lib/activity_percentage_calculator.rb
+++ b/lib/activity_percentage_calculator.rb
@@ -14,6 +14,7 @@ class ActivityPercentageCalculator
   end
 
   def percentage_of_outside_activities
+    return 0 if outside_activities == 0 && inside_activities == 0
     ((outside_activities.to_f / (inside_activities + outside_activities).to_f) * 100).to_i
   end
 
@@ -24,7 +25,7 @@ class ActivityPercentageCalculator
           id: 1,
           percentage_outside: percentage_of_outside_activities,
           inside: inside_activities,
-          outside: outside_activities
+          outside: outside_activities,
         }
       ]
     }

--- a/lib/location_proximity_query.rb
+++ b/lib/location_proximity_query.rb
@@ -1,4 +1,4 @@
-class AqoLocationProximityQuery
+class LocationProximityQuery
   attr_reader :observations, :zip_code, :lat, :lng
 
   def initialize(observations, opts = {})
@@ -9,11 +9,7 @@ class AqoLocationProximityQuery
   end
 
   def focal_point
-    if zip_code
-      observations.closest(origin: zip_code).first
-    else
-      observations.closest(origin: [lat, lng]).first
-    end
+    zip_code || [lat, lng]
   end
 
   def nearby

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -7,14 +7,20 @@ describe Api::ActivitiesController do
     let(:inside_activities) { Activity.where(location: 'inside').count }
     let(:outside_activities) { Activity.where(location: 'outside').count }
 
-    before do
-      @activities = create_list(:activity, 20)
-    end
+    context 'with zip code' do
+      before do
+        # Tokyo
+        create_list(:activity, 20, lat: 35.6833, lng: 39.6833)
+        # SB
+        Activity.create(date: Time.zone.now, location: 'inside', lat: 35.9927473, lng: -78.9061682)
+        Activity.create(date: Time.zone.now, location: 'outside', lat: 35.9927473, lng: -78.9061682)
+      end
 
-    it 'gets activities for a specific date' do
-      get :index, date: Time.zone.now.strftime("%d/%m/%Y")
-      expect(json['activities'].first['inside']).to eq inside_activities
-      expect(json['activities'].first['outside']).to eq outside_activities
+      it 'will only get activities near zip code' do
+        get :index, date: Time.zone.now.strftime("%d/%m/%Y"), zip_code: 27701
+        expect(json['activities'].first['inside']).to eq 1
+        expect(json['activities'].first['outside']).to eq 1
+      end
     end
   end
 

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -17,7 +17,7 @@ describe Api::ActivitiesController do
       end
 
       it 'will only get activities near zip code' do
-        get :index, date: Time.zone.now.strftime("%d/%m/%Y"), zip_code: 27701
+        get :index, date: Time.zone.now.strftime("%d/%m/%Y"), zip_code: '27701'
         expect(json['activities'].first['inside']).to eq 1
         expect(json['activities'].first['outside']).to eq 1
       end

--- a/spec/controllers/air_quality_observations_controller_spec.rb
+++ b/spec/controllers/air_quality_observations_controller_spec.rb
@@ -9,7 +9,13 @@ describe Api::AirQualityObservationsController do
 
   describe 'index' do
     let!(:nearby_observations) do
-      create_list(:air_quality_observation, 5, reporting_area: "R'lyeh", lat: 40.5, lng: 47.5)
+      create_list(
+        :air_quality_observation,
+        5,
+        reporting_area: "R'lyeh",
+        lat: 40.5,
+        lng: 47.5
+      )
     end
     let(:lat) { nearby_observations.first.lat + 1 }
     let(:lng) { nearby_observations.first.lng + 1 }


### PR DESCRIPTION
## What Changed?
- You can pass zip code to the activity endpoint to get activities 100miles from that zip code
## Why
- So the Ember application's activities will update when you change locations
